### PR TITLE
fix: concurrent fresh calls should create distinct vars

### DIFF
--- a/microkanren/microKanren.py
+++ b/microkanren/microKanren.py
@@ -57,7 +57,16 @@ def unify(u: term, v: term, s: substitutions) -> Optional[substitutions]:
 def fresh(f: Callable[[VarArg(term)], goal]) -> goal:
     def _fresh(subs: substitutions):
         term_names = [str(term) for term in inspect.signature(f).parameters]
-        terms = [Var(term) for term in term_names]
+        terms = []
+        for term in term_names:
+            v = Var(term)
+            i = 0
+            while v in subs:
+                i += 1
+                v = Var(term + str(i))
+
+            terms.append(v)
+
         return f(*terms)(subs)
     return _fresh
 

--- a/tests/test_microkanren.py
+++ b/tests/test_microkanren.py
@@ -97,3 +97,13 @@ def test_multiple_fresh_terms():
 
     result = g({})
     assert result == [{'x': 'hello', 'y': 'hello'}]
+
+
+def test_name_collision():
+    g = conj(
+        fresh(lambda x: eq(x, 'hello')),
+        fresh(lambda x: eq(x, 'bye')),
+    )
+
+    result = g({})
+    assert result == [{'x': 'hello', 'x1': 'bye'}]


### PR DESCRIPTION
latest improvements broke fresh when we have concurrent calls with the same names:

    conj(
        fresh(lambda x: eq(x, 'hello')),
        fresh(lambda x: eq(x, 'bye')),
    )

The two lambdas should create distinct variables so we should end up with two substitutions with the first x == 'hello', second x == 'bye'